### PR TITLE
added support for multi-bytes prefixes networks

### DIFF
--- a/coinlib/lib/src/network_params.dart
+++ b/coinlib/lib/src/network_params.dart
@@ -2,8 +2,8 @@
 class NetworkParams {
 
   final int wifPrefix;
-  final int p2pkhPrefix;
-  final int p2shPrefix;
+  final List<int> p2pkhPrefix;
+  final List<int> p2shPrefix;
   final int privHDPrefix;
   final int pubHDPrefix;
   final String bech32Hrp;
@@ -21,8 +21,8 @@ class NetworkParams {
 
   static const mainnet = NetworkParams(
     wifPrefix: 183,
-    p2pkhPrefix: 55,
-    p2shPrefix: 117,
+    p2pkhPrefix: [55],
+    p2shPrefix: [117],
     privHDPrefix: 0x0488ade4,
     pubHDPrefix: 0x0488b21e,
     bech32Hrp: "pc",
@@ -31,8 +31,8 @@ class NetworkParams {
 
   static const testnet = NetworkParams(
     wifPrefix: 239,
-    p2pkhPrefix: 111,
-    p2shPrefix: 196,
+    p2pkhPrefix: [111],
+    p2shPrefix: [196],
     privHDPrefix: 0x043587CF,
     pubHDPrefix: 0x04358394,
     bech32Hrp: "tpc",

--- a/coinlib/test/address_test.dart
+++ b/coinlib/test/address_test.dart
@@ -4,8 +4,8 @@ import 'package:test/test.dart';
 
 const wrongNetwork = NetworkParams(
   wifPrefix: 0,
-  p2pkhPrefix: 0xfa,
-  p2shPrefix: 0xfb,
+  p2pkhPrefix: [0xfa],
+  p2shPrefix: [0xfb],
   privHDPrefix: 0,
   pubHDPrefix: 0,
   bech32Hrp: "wrong",
@@ -266,7 +266,7 @@ void main() {
     test("invalid base58 version", () {
       for (final v in [-1, 256]) {
         expect(
-          () => P2PKHAddress.fromPublicKey(pubkey, version: v),
+          () => P2PKHAddress.fromPublicKey(pubkey, version: [v]),
           throwsArgumentError,
         );
       }
@@ -334,7 +334,7 @@ void main() {
       expectValidAddress(
         "${longHrp}1sqqqs3t97ut",
         NetworkParams(
-          wifPrefix: 0, p2shPrefix: 0, p2pkhPrefix: 0,
+          wifPrefix: 0, p2shPrefix: [0], p2pkhPrefix: [0],
           privHDPrefix: 0, pubHDPrefix: 0,
           bech32Hrp: longHrp, messagePrefix: "",
         ),
@@ -355,7 +355,7 @@ void main() {
   group("Base58Address", () {
     test(".hash is copied and cannot be mutated", () {
       final hash = Uint8List(20);
-      final addr = P2PKHAddress.fromHash(hash, version: 0);
+      final addr = P2PKHAddress.fromHash(hash, version: [0]);
       addr.hash[0] = 0xff;
       hash[1] = 0xff;
       expect(addr.hash, Uint8List(20));


### PR DESCRIPTION
Attempt to extend the current simple byte implementation of Network support for multiple prefix bytes for other chains with custom address prefixes.