### PR TITLE
Fix secp256k1 build when only docker is available

### DIFF
--- a/coinlib/bin/docker_util.dart
+++ b/coinlib/bin/docker_util.dart
@@ -25,7 +25,7 @@ Future<bool> dockerRun(
   // Build
   print("Building $tag");
   var exitCode = await execWithStdio(
-    dockerCmd, ["build", "-f", "-", "-t", tag],
+    dockerCmd, ["build", "-t", tag, "-"],
     stdin: dockerScript,
   );
 

--- a/coinlib/bin/util.dart
+++ b/coinlib/bin/util.dart
@@ -29,7 +29,11 @@ Future<int> execWithStdio(
     await process.stdin.close();
   }
 
-  await process.stdout.transform(utf8.decoder).forEach(stdout.write);
+  // Pipe stdout to terminal and discard stderr
+  await Future.wait([
+    process.stdout.transform(utf8.decoder).forEach(stdout.write),
+    process.stderr.drain<String?>(),
+  ]);
 
   return await process.exitCode;
 }


### PR DESCRIPTION
In `dockerRun` of `coinlib/bin/docker_util.dart`, docker is invoked as such:
```
docker build -f - -t coinlib_build_secp256k1_linux
```

However, this is invalid syntax and causes the following error:
```
ERROR: "docker buildx build" requires exactly 1 argument.
See 'docker buildx build --help'.

Usage:  docker buildx build [OPTIONS] PATH | URL | -

Start a build
```
This error was previously undiscovered possibly because podman accepts the existing syntax, and `getDockerCmd` doesn't use docker unless podman isn't installed.

This PR fixes building with docker by changing the invoked command to:
```
(docker or podman) build -t coinlib_build_secp256k1_linux -
```
Which is valid to both docker and podman  

Additionally, discard stderr in `execWithStdio` with `.drain<String?>()`, which is (somehow) required for `docker build` to not get stuck at the end of the build