### PR TITLE
Build secp256k1 via cmake ExternalProject, no pre-built DLL required.

### DIFF
--- a/.github/workflows/test-windows-cmake.yml
+++ b/.github/workflows/test-windows-cmake.yml
@@ -1,0 +1,70 @@
+name: Test Windows cmake ExternalProject build
+
+# Verifies that flutter build windows works with the cmake ExternalProject
+# approach for building secp256k1 — no pre-built DLL required.
+on:
+  push:
+    branches:
+      - fix/windows-cmake-externalproject
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Enable Windows desktop
+        run: flutter config --enable-windows-desktop
+
+      - name: Override coinlib_flutter with local path
+        run: |
+          echo "dependency_overrides:" > coinlib_flutter/example/pubspec_overrides.yaml
+          echo "  coinlib_flutter:" >> coinlib_flutter/example/pubspec_overrides.yaml
+          echo "    path: .." >> coinlib_flutter/example/pubspec_overrides.yaml
+        shell: bash
+
+      - name: Get dependencies
+        run: flutter pub get
+        working-directory: coinlib_flutter/example
+
+      - name: Build Windows release
+        run: flutter build windows --release
+        working-directory: coinlib_flutter/example
+
+      - name: Verify secp256k1.dll is bundled
+        run: |
+          $dll = "build\windows\x64\runner\Release\secp256k1.dll"
+          if (!(Test-Path $dll)) {
+            Write-Error "secp256k1.dll not found at $dll — cmake ExternalProject may not have run or DLL rename failed"
+            exit 1
+          }
+          $size = (Get-Item $dll).Length
+          Write-Host "PASS: secp256k1.dll found at $dll ($size bytes)"
+        shell: pwsh
+        working-directory: coinlib_flutter/example
+
+      - name: Upload ExternalProject logs
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: secp256k1-externalproject-logs
+          path: coinlib_flutter/example/build/windows/x64/secp256k1/
+          if-no-files-found: warn
+
+      - name: Upload build output
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: windows-release-bundle
+          path: coinlib_flutter/example/build/windows/x64/runner/Release/
+          if-no-files-found: warn

--- a/coinlib/README.md
+++ b/coinlib/README.md
@@ -85,6 +85,9 @@ place the library under a `build` directory.
 
 ## Building for Windows
 
+When using `coinlib_flutter` the native library is built automatically by cmake.
+The scripts below are only needed when using `coinlib` directly outside of Flutter.
+
 ### Native Windows build
 
 **Please note that native windows builds under this section can sometimes freeze
@@ -96,7 +99,7 @@ Building on Windows requires CMake as a dependency.
 
 The Windows shared library can be built using `dart run coinlib:build_windows` in
 the root directory of your package which will produce a shared library into
-`build/libsecp256k1.dll`. This can also be run in the `coinlib` root directory
+`build/secp256k1.dll`. This can also be run in the `coinlib` root directory
 via `dart run bin/build_windows.dart`.
 
 Windows builds use the Visual Studio 17 2022 generator.  Earlier Visual Studio

--- a/coinlib_flutter/README.md
+++ b/coinlib_flutter/README.md
@@ -26,8 +26,7 @@ An example app is provided in `example/` that demonstrates use of the loader
 widget. Beyond this, the [coinlib](https://pub.dev/packages/coinlib) library
 documentation can be followed.
 
-Android, iOS, Linux, macOS, web, and Windows are supported. If you are using the
-package for Android, iOS, Linux, macOS or web, the library is ready to use. For
-Windows, run `dart run coinlib:build_windows` to build the library. See
-[coinlib's documentation](https://pub.dev/packages/coinlib) for more detailed
-instructions on and options for building the native library.
+Android, iOS, Linux, macOS, web, and Windows are supported. All platforms work
+out of the box after adding the package dependency. See
+[coinlib's documentation](https://pub.dev/packages/coinlib) for information on
+building the native library for use outside of Flutter.

--- a/coinlib_flutter/src/CMakeLists.txt
+++ b/coinlib_flutter/src/CMakeLists.txt
@@ -10,7 +10,13 @@ project(coinlib_library VERSION 1.0.0 LANGUAGES C)
 include(ExternalProject)
 
 set(SECP256K1_PREFIX ${CMAKE_BINARY_DIR}/secp256k1)
-set(SECP256K1_CFLAGS "-O2 ${CMAKE_C_FLAGS}")
+
+# MSVC uses /O2 via CMAKE_BUILD_TYPE; -O2 is not a valid MSVC flag.
+if(MSVC)
+  set(SECP256K1_CFLAGS "${CMAKE_C_FLAGS}")
+else()
+  set(SECP256K1_CFLAGS "-O2 ${CMAKE_C_FLAGS}")
+endif()
 
 set(
   SECP256K1_ARGS
@@ -40,6 +46,15 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL Android)
   )
 endif()
 
+# Visual Studio generator requires explicit --config; CMAKE_BUILD_TYPE is ignored.
+if(CMAKE_CONFIGURATION_TYPES)
+  set(SECP256K1_BUILD_CMD   ${CMAKE_COMMAND} --build   . --config $<CONFIG>)
+  set(SECP256K1_INSTALL_CMD ${CMAKE_COMMAND} --install . --config $<CONFIG>)
+else()
+  set(SECP256K1_BUILD_CMD   ${CMAKE_COMMAND} --build   .)
+  set(SECP256K1_INSTALL_CMD ${CMAKE_COMMAND} --install .)
+endif()
+
 ExternalProject_Add(
 
   secp256k1
@@ -52,42 +67,80 @@ ExternalProject_Add(
   # This is necessary to ensure CMake doesn't add cache settings
   CMAKE_GENERATOR ${CMAKE_GENERATOR}
 
+  # Required for Visual Studio to target the correct architecture.
+  CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
+  CMAKE_GENERATOR_TOOLSET  ${CMAKE_GENERATOR_TOOLSET}
+
   CMAKE_ARGS ${SECP256K1_ARGS}
+
+  BUILD_COMMAND   ${SECP256K1_BUILD_CMD}
+  INSTALL_COMMAND ${SECP256K1_INSTALL_CMD}
 
 )
 
 # Post-build processing of library file
 # Move output library to the correct place
 
-set(SECP256K1_VERSIONEDLIB ${SECP256K1_PREFIX}/lib/libsecp256k1.so.2.2.0)
-set(SECP255K1_FINALLIB ${SECP256K1_PREFIX}/lib/libsecp256k1.so)
+if(WIN32)
 
-# Move any versioned .so file to an unversioned .so file.
-# If the versioned file doesn't exist this shouldn't fail as the destination
-# should have been built already
-add_custom_target(
-  removeVersion
-  ALL
-  COMMAND ${CMAKE_COMMAND} -E rename
-    ${SECP256K1_VERSIONEDLIB}
-    ${SECP255K1_FINALLIB}
-    || exit 0
-)
-add_dependencies(removeVersion secp256k1)
+  set(SECP256K1_BIN_DIR ${SECP256K1_PREFIX}/bin)
+  set(SECP256K1_FINAL_DLL ${SECP256K1_BIN_DIR}/secp256k1.dll)
 
-# For Android, move library to JNI directory
-if (${CMAKE_SYSTEM_NAME} STREQUAL Android)
-  set(
-    JNI_DIR
-    ${CMAKE_CURRENT_SOURCE_DIR}/../android/src/main/jniLibs/${ANDROID_ABI}
+  # Rename the versioned DLL (e.g. libsecp256k1-2.dll) to secp256k1.dll.
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/install_secp256k1_dll.cmake [=[
+    file(GLOB _versioned_dlls LIST_DIRECTORIES false "${BIN_DIR}/*secp256k1-*.dll")
+    if(NOT _versioned_dlls)
+      message(FATAL_ERROR "secp256k1 DLL not found (${BIN_DIR}/*secp256k1-*.dll)")
+    endif()
+    list(GET _versioned_dlls 0 _versioned)
+    file(RENAME "${_versioned}" "${BIN_DIR}/secp256k1.dll")
+  ]=])
+
+  ExternalProject_Add_Step(secp256k1 renameDll
+    COMMAND ${CMAKE_COMMAND}
+      -DBIN_DIR=${SECP256K1_BIN_DIR}
+      -P ${CMAKE_CURRENT_BINARY_DIR}/install_secp256k1_dll.cmake
+    DEPENDEES install
+    ALWAYS OFF
   )
+
+  set(SECP256K1_OUTPUT ${SECP256K1_FINAL_DLL} PARENT_SCOPE)
+
+else()
+
+  set(SECP256K1_VERSIONEDLIB ${SECP256K1_PREFIX}/lib/libsecp256k1.so.2.2.0)
+  set(SECP255K1_FINALLIB ${SECP256K1_PREFIX}/lib/libsecp256k1.so)
+
+  # Move any versioned .so file to an unversioned .so file.
+  # If the versioned file doesn't exist this shouldn't fail as the destination
+  # should have been built already
   add_custom_target(
-    moveAndroid
+    removeVersion
     ALL
-    COMMAND mkdir -p ${JNI_DIR}
     COMMAND ${CMAKE_COMMAND} -E rename
+      ${SECP256K1_VERSIONEDLIB}
       ${SECP255K1_FINALLIB}
-      ${JNI_DIR}/libsecp256k1.so
+      || exit 0
   )
-  add_dependencies(moveAndroid removeVersion)
+  add_dependencies(removeVersion secp256k1)
+
+  set(SECP256K1_OUTPUT ${SECP255K1_FINALLIB} PARENT_SCOPE)
+
+  # For Android, move library to JNI directory
+  if (${CMAKE_SYSTEM_NAME} STREQUAL Android)
+    set(
+      JNI_DIR
+      ${CMAKE_CURRENT_SOURCE_DIR}/../android/src/main/jniLibs/${ANDROID_ABI}
+    )
+    add_custom_target(
+      moveAndroid
+      ALL
+      COMMAND mkdir -p ${JNI_DIR}
+      COMMAND ${CMAKE_COMMAND} -E rename
+        ${SECP255K1_FINALLIB}
+        ${JNI_DIR}/libsecp256k1.so
+    )
+    add_dependencies(moveAndroid removeVersion)
+  endif()
+
 endif()

--- a/coinlib_flutter/windows/CMakeLists.txt
+++ b/coinlib_flutter/windows/CMakeLists.txt
@@ -8,42 +8,11 @@ cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME "coinlib_flutter")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
-# Invoke the build for native code shared with the other target platforms.
-# This can be changed to accommodate different builds.
-# add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DIR}/shared")
-# TODO re-enable the above line if/when the CMake process is made Windows-compatible.
-# See also below.
+# Build secp256k1 via cmake ExternalProject (sets SECP256K1_OUTPUT in this scope).
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DIR}/shared")
 
-# Search for secp256k1.dll in multiple possible directories.
-#
-# This is only necessary because in testing we have found that most Windows hosts
-# have CMAKE_BINARY_DIR = app/build/windows/x64, but some use app/build/windows.
-# This should search through its multiple possible locations. 
-find_file(SECP256K1_DLL
-    NAMES secp256k1.dll
-    PATHS
-        "${CMAKE_BINARY_DIR}/../"           # Check one level up.
-        "${CMAKE_BINARY_DIR}/../../"        # Check two levels up.
-        "${CMAKE_BINARY_DIR}/../../../"     # Used for the example app.
-        "${CMAKE_SOURCE_DIR}/../build"
-        "${CMAKE_SOURCE_DIR}/../../build"   # Works for the example app.
-    NO_DEFAULT_PATH
+# Bundle the built secp256k1.dll with the plugin.
+set(coinlib_flutter_bundled_libraries
+  ${SECP256K1_OUTPUT}
+  PARENT_SCOPE
 )
-
-# Check if SECP256K1_DLL was found
-if (SECP256K1_DLL)
-    # List of absolute paths to libraries that should be bundled with the plugin.
-    # This list could contain prebuilt libraries, or libraries created by an
-    # external build triggered from this build file.
-    set(coinlib_flutter_bundled_libraries
-        # Defined in ../src/CMakeLists.txt.
-        # This can be changed to accommodate different builds.
-        # $<TARGET_FILE:coinlib_flutter>
-        # TODO re-enable if/when the CMake process is made Windows-compatible.
-        # See also above.
-        ${SECP256K1_DLL}
-        PARENT_SCOPE
-    )
-else ()
-    message(FATAL_ERROR "Could not find secp256k1.dll.")
-endif ()


### PR DESCRIPTION
Resolves the TODO in windows/CMakeLists.txt, so re-enables add_subdirectory in src/CMakeLists.txt so secp256k1 is built via cmake ExternalProject during flutter build windows, the same way it works on Linux and Android. No pre-built DLL required.
  
  Tested on windows-latest (Windows Server 2025, VS 2026): https://github.com/cypherstack/coinlib/actions/runs/26660965448/job/78583115194