### PR TITLE
Update pointycastle

### DIFF
--- a/coinlib/pubspec.yaml
+++ b/coinlib/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   ffi: ^2.1.0
   hex: ^0.2.0
   path: ^1.8.0
-  pointycastle: ^3.7.3
+  pointycastle: ^4.0.0
 
 ffigen:
   name: NativeSecp256k1


### PR DESCRIPTION
Hi all, in doing some maintenance on our fork of coinlib, I decided to break out the differences between cypherstack/coinlib and its peercoin/coinlib base. This is one of those differences: RIPEMD-160 support.  You may close this if you don't need or want RIPEMD-160 :)