### PR TITLE
android 16KB page sizes

### DIFF
--- a/coinlib_flutter/android/build.gradle
+++ b/coinlib_flutter/android/build.gradle
@@ -4,14 +4,14 @@ group 'com.example.coinlib_flutter'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = "2.2.10"
+    ext.kotlin_version = "2.2.20"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("com.android.tools.build:gradle:8.7.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -36,7 +36,7 @@ android {
 
     // Bumping the plugin ndkVersion requires all clients of this plugin to bump
     // the version in their app and to download a newer version of the NDK.
-    ndkVersion "21.4.7075529"
+    ndkVersion = "28.0.13004108"
 
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {


### PR DESCRIPTION
Hi all, in doing some maintenance on our fork of coinlib, I decided to break out the differences between cypherstack/coinlib and its peercoin/coinlib base. This is one of those differences: support for new Android 16kb pages.