### PR TITLE
fix(android): align secp256k1 .so to 16 KB page size

### DIFF
--- a/coinlib_flutter/src/CMakeLists.txt
+++ b/coinlib_flutter/src/CMakeLists.txt
@@ -37,6 +37,8 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL Android)
     -DANDROID_NDK=${ANDROID_NDK}
     -DANDROID_ABI=${ANDROID_ABI}
     -DANDROID_PLATFORM=${ANDROID_PLATFORM}
+    # Align ELF LOAD segments to 16 KB for Android 15+ page size requirement
+    -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=16384
   )
 endif()
 


### PR DESCRIPTION
confirmed fix for google play store 16 kb page requirement